### PR TITLE
Mos-23 cuando una orden este en estado entregado se muestra unicamente en el historial del cliente

### DIFF
--- a/app/Filament/Resources/ClientResource.php
+++ b/app/Filament/Resources/ClientResource.php
@@ -138,7 +138,7 @@ class ClientResource extends Resource
     public static function getRelations(): array
     {
         return [
-            //
+            RelationManagers\OrdersRelationManager::class,
         ];
     }
     

--- a/app/Filament/Resources/ClientResource/Pages/ViewClient.php
+++ b/app/Filament/Resources/ClientResource/Pages/ViewClient.php
@@ -16,4 +16,9 @@ class ViewClient extends ViewRecord
             Actions\EditAction::make(),
         ];
     }
+
+    public function hasCombinedRelationManagerTabsWithForm(): bool
+    {
+        return true;
+    }
 }

--- a/app/Filament/Resources/ClientResource/RelationManagers/OrdersRelationManager.php
+++ b/app/Filament/Resources/ClientResource/RelationManagers/OrdersRelationManager.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace App\Filament\Resources\ClientResource\RelationManagers;
+
+use Filament\Forms;
+use Filament\Resources\Form;
+use Filament\Resources\RelationManagers\RelationManager;
+use Filament\Resources\Table;
+use Filament\Tables;
+use Filament\Tables\Columns\TextColumn;
+use Filament\Tables\Actions\Action;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\SoftDeletingScope;
+use Illuminate\Database\Eloquent\Model;
+
+class OrdersRelationManager extends RelationManager
+{
+    protected static string $relationship = 'orders';
+
+    protected static ?string $recordTitleAttribute = 'key';
+    protected static ?string $navigationLabel = 'Ordenes';
+    protected static ?string $pluralModelLabel = 'Ordenes';
+
+    public static function form(Form $form): Form
+    {
+        return $form
+            ->schema([
+                Forms\Components\TextInput::make('key')
+                    ->required()
+                    ->maxLength(255),
+            ]);
+    }
+
+    public static function table(Table $table): Table
+    {
+        return $table
+            ->columns([
+                TextColumn::make('key'),
+                TextColumn::make('total')
+                    ->money('gtq', true),
+                TextColumn::make('branch_id')
+                    ->label('Sucursal')
+                    ->getStateUsing(function (Model $record) {
+                        return $record->branch->name;
+                    }),
+                TextColumn::make('created_at')
+                    ->dateTime()
+                    ->label('Fecha de Creación'),
+            ])
+            ->filters([
+                //
+            ])
+            ->headerActions([
+
+            ])
+            ->actions([
+                Action::make("goToOrder")
+                    ->label("Ver Orden")
+                    ->action(function (Model $record) {
+                        redirect()->intended('/admin/orders/'.str($record->id));
+                    }),
+            ])
+            ->bulkActions([
+
+            ]);
+    }    
+}

--- a/app/Filament/Resources/OrderResource.php
+++ b/app/Filament/Resources/OrderResource.php
@@ -134,10 +134,6 @@ class OrderResource extends Resource
                     ->options(
                         OrderState::get()->pluck('name', 'id')
                     ),
-                Filter::make('noEntregados')
-                    ->label('No mostrar entregados')
-                    ->query(fn (Builder $query): Builder => $query->whereNot('state_id', OrderState::where('name', 'Entregado')->first()->id))
-                    ->default(true)
             ])
             ->actions([
                 Action::make("nextStatus")

--- a/app/Filament/Resources/OrderResource/Pages/ListOrders.php
+++ b/app/Filament/Resources/OrderResource/Pages/ListOrders.php
@@ -16,10 +16,10 @@ class ListOrders extends ListRecords
 {
     protected static string $resource = OrderResource::class;
 
-    // protected function getTableQuery(): Builder
-    // {
-    //     return Order::query()->whereNot('state_id', 2);
-    // }
+    protected function getTableQuery(): Builder
+    {
+        return Order::query()->whereNot('state_id', 2);
+    }
 
     protected function getActions(): array
     {

--- a/app/Filament/Resources/OrderResource/RelationManagers/ProductsRelationManager.php
+++ b/app/Filament/Resources/OrderResource/RelationManagers/ProductsRelationManager.php
@@ -27,7 +27,7 @@ class ProductsRelationManager extends RelationManager
     protected static string $relationship = 'products';
 
     protected static ?string $recordTitleAttribute = 'name';
-    protected static ?string $navigationLabel = 'Pagos';
+    protected static ?string $navigationLabel = 'Productos';
     protected static ?string $pluralModelLabel = 'Productos';
 
     protected static $orderService;

--- a/app/Models/Client.php
+++ b/app/Models/Client.php
@@ -26,4 +26,12 @@ class Client extends Model
     {
         return $this->belongsTo(Municipio::class);
     }
+
+    /**
+     * Get all the orders for the client.
+     */
+    public function orders()
+    {
+        return $this->hasMany(Order::class);
+    }
 }


### PR DESCRIPTION
Se agrego un filtro por default para no ver las ordenes que esten en estado de 'Entregado' esto con el motivo de si la persona quiere ver las ordenes entregadas por el clientre puede hacerlo

Como alternativa en comentario se puede cargar los datos ya sin las ordenes entregadas.
